### PR TITLE
Add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,47 @@
+pull_request_rules:
+  - name: 'rebase unreviewed non-release PRs'
+    conditions:
+      - head~=^(?!(release|hotfix)).*$
+      - status-success=Travis CI - Branch
+      - status-success=Travis CI - Pull Request
+      - status-success=SonarCloud Code Analysis
+      - status-success=verification/cla-signed
+      - "#approved-reviews-by<=0"
+      - "#changes-requested-reviews-by<=0"
+    actions:
+      rebase: {}
+
+  - name: 'merge non-release PRs with strict rebase'
+    conditions:
+      - head~=^(?!(release|hotfix)).*$
+      - status-success=Travis CI - Branch
+      - status-success=Travis CI - Pull Request
+      - status-success=SonarCloud Code Analysis
+      - status-success=verification/cla-signed
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by<=0"
+    actions:
+      merge:
+        strict: true
+        strict_method: rebase
+        method: merge
+
+  - name: 'merge release PRs with strict merge'
+    conditions:
+      - head~=^(release|hotfix).*$
+      - status-success=Travis CI - Branch
+      - status-success=Travis CI - Pull Request
+      - status-success=SonarCloud Code Analysis
+      - status-success=verification/cla-signed
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by<=0"
+    actions:
+      merge:
+        strict: true
+        method: merge
+
+  - name: 'delete PR branches after merge'
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
The mergify config has been copied from [retest/recheck/.mergify.yml](https://github.com/retest/recheck/blob/master/.mergify.yml) with the status checks removed. Although we most probably will not have a release process here, I did not modify anything else, just to eliminate any diverging versions (status checks should be handled by the branch protection rules).

I would also recommend to enable dependabot (either via the web interface or via `.dependabot/config.yml`), so that we do not have to update the dependency versions manually.

However, I would argue that we want:

1. a build for that (Travis or GitHub Actions)
2. enable branch protection with
    1. "Require pull request reviews before merging"
    2. "Require status checks to pass before merging"
    3. "Require branches to be up to date before merging"
    4. "Enable status checks"
    5. "Include administrators"