### PR TITLE
Feature/use recommended setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 			<groupId>de.retest</groupId>
 			<artifactId>recheck-web</artifactId>
 			<version>1.10.1</version>
+			<scope>test</scope>
 		</dependency>
 		<!-- JUnit -->
 		<dependency>

--- a/src/test/java/de/retest/quickstarts/BasicDemo.java
+++ b/src/test/java/de/retest/quickstarts/BasicDemo.java
@@ -1,7 +1,7 @@
 package de.retest.quickstarts;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -16,21 +16,19 @@ import de.retest.recheck.RecheckOptions;
 @RunWith( JUnit4.class )
 public class BasicDemo {
 
-	static WebDriver driver;
-	static Recheck re;
+	WebDriver driver;
+	Recheck re;
 
-	@BeforeClass
-	public static void setup() {
-		// Must be before ALL tests (at Class-level)
-
-		ChromeOptions options = new ChromeOptions() //
+	@Before
+	public void setup() {
+		final ChromeOptions options = new ChromeOptions() //
 				.addArguments( // 
 						"--headless", //
 						"--no-sandbox", //
 						"--window-size=1200,800" );
 		driver = new ChromeDriver( options );
 
-		RecheckOptions recheckOptions = RecheckOptions.builder() //
+		final RecheckOptions recheckOptions = RecheckOptions.builder() //
 				.enableReportUpload() //
 				.build();
 		re = new RecheckImpl( recheckOptions );
@@ -43,7 +41,7 @@ public class BasicDemo {
 
 		// Navigate the browser to the demo page.
 		driver.get( "https://demo.retest.org/start.html" );
-		
+
 		// To see visual bugs after the first run, use the commented line below instead.
 		//driver.get("https://demo.retest.org/changed.html");
 
@@ -54,8 +52,8 @@ public class BasicDemo {
 		re.capTest();
 	}
 
-	@AfterClass
-	public static void shutdown() {
+	@After
+	public void shutdown() {
 		// Close the browser.
 		driver.quit();
 


### PR DESCRIPTION
In our [docs](https://docs.retest.de/recheck/introduction/usage/#junit-4-vintage), we state that a browser and the corresponding recheck instance should be in `@Before` so that it is created again for each method execution.

Secondly I would argue, that we do not want to push either JUnit4 or Java 8, as both have a successor.

1. JUnit4 -> JUnit5: We do not need compatibility here in a tutorial project, thus we should use the versions we recommend.
2. Java8 -> at least Java 11: I would only use Java8 if this is an API. But since it is an isolated project I would use the recommended LTS Java version 11.
3. Use our extension: I would also recommend to use our extension to handle the lifecycle to avoid any mistakes. While it is good to see at least one test without the lifecycle to understand the implications behind it, I would at least note this as comment or write a separate test.